### PR TITLE
Add ElectrumX get block headers method and tests

### DIFF
--- a/src/electrumx.js
+++ b/src/electrumx.js
@@ -391,6 +391,60 @@ class ElectrumX {
       else throw error
     }
   }
+
+  /**
+   * @api Electrumx.blockHeader()  blockHeader()
+   * @apiName ElectrumX Block headers
+   * @apiGroup ElectrumX
+   * @apiDescription Return block headers for a given height
+   *
+   * @apiExample Example usage:
+   * (async () => {
+   *   try {
+   *     let headers = await bchjs.Electrumx.blockHeaders(42);
+   *     console.log(headers);
+   *   } catch(error) {
+   *    console.error(error)
+   *   }
+   * })()
+   *
+   * headers = {
+   *  "success": true,
+   *  "headers": [
+   *    "010000008b52bbd72c2f49569059f559c1b1794de5192e4f7d6d2b03c7482bad0000000083e4f8a9d502ed0c419075c1abb5d56f878a2e9079e5612bfb76a2dc37d9c42741dd6849ffff001d2b909dd6",
+   *    "01000000f528fac1bcb685d0cd6c792320af0300a5ce15d687c7149548904e31000000004e8985a786d864f21e9cbb7cbdf4bc9265fe681b7a0893ac55a8e919ce035c2f85de6849ffff001d385ccb7c"
+   *  ]
+   * }
+   *
+   * (async () => {
+   *   try {
+   *     let headers = await bchjs.Electrumx.blockHeaders(42, 1);
+   *     console.log(headers);
+   *   } catch(error) {
+   *    console.error(error)
+   *   }
+   * })()
+   *
+   * headers = {
+   *  "success": true,
+   *  "headers": [
+   *    "010000008b52bbd72c2f49569059f559c1b1794de5192e4f7d6d2b03c7482bad0000000083e4f8a9d502ed0c419075c1abb5d56f878a2e9079e5612bfb76a2dc37d9c42741dd6849ffff001d2b909dd6"
+   *  ]
+   * }
+   *
+   */
+  async blockHeader(height, count = 1) {
+    try {
+      const response = await axios.get(
+        `${this.restURL}electrumx/block/headers/${height}?count=${count}`,
+        _this.axiosOptions
+      )
+      return response.data
+    } catch (error) {
+      if (error.response && error.response.data) throw error.response.data
+      else throw error
+    }
+  }
 }
 
 module.exports = ElectrumX

--- a/test/integration/electrumx.js
+++ b/test/integration/electrumx.js
@@ -240,4 +240,31 @@ describe(`#ElectrumX`, () => {
       }
     })
   })
+
+  describe(`#blockHeader`, () => {
+    it(`should GET block headers for given height and count`, async () => {
+      const height = 42
+      const count = 2
+
+      const result = await bchjs.Electrumx.blockHeader(height, count)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+      assert.property(result, "success")
+      assert.equal(result.success, true)
+
+      assert.property(result, "headers")
+      assert.isArray(result.headers)
+      assert.equal(result.headers.length, 2)
+    })
+    it(`should GET block headers for given height with default count = 1`, async () => {
+      const height = 42
+
+      const result = await bchjs.Electrumx.blockHeader(height)
+      assert.property(result, "success")
+      assert.equal(result.success, true)
+
+      assert.property(result, "headers")
+      assert.isArray(result.headers)
+      assert.equal(result.headers.length, 1)
+    })
+  })
 })

--- a/test/integration/testnet/electrumx.js
+++ b/test/integration/testnet/electrumx.js
@@ -244,4 +244,31 @@ describe(`#ElectrumX`, () => {
       }
     })
   })
+
+  describe(`#blockHeader`, () => {
+    it(`should GET block headers for given height and count`, async () => {
+      const height = 42
+      const count = 2
+
+      const result = await bchjs.Electrumx.blockHeader(height, count)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+      assert.property(result, "success")
+      assert.equal(result.success, true)
+
+      assert.property(result, "headers")
+      assert.isArray(result.headers)
+      assert.equal(result.headers.length, 2)
+    })
+    it(`should GET block headers for given height with default count = 1`, async () => {
+      const height = 42
+
+      const result = await bchjs.Electrumx.blockHeader(height)
+      assert.property(result, "success")
+      assert.equal(result.success, true)
+
+      assert.property(result, "headers")
+      assert.isArray(result.headers)
+      assert.equal(result.headers.length, 1)
+    })
+  })
 })

--- a/test/unit/electrumx.js
+++ b/test/unit/electrumx.js
@@ -260,4 +260,40 @@ describe(`#ElectrumX`, () => {
       assert.property(result.utxos[0].utxos[0], "fee")
     })
   })
+
+  describe(`#blockHeader`, () => {
+    it(`should throw an error for improper height input`, async () => {
+      try {
+        const height = -10
+        await bchjs.Electrumx.blockHeader(height)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        // console.log(`err: `, err)
+        assert.include(err.error, `height must be a positive number`)
+      }
+    })
+    it(`should throw an error for improper count input`, async () => {
+      try {
+        const height = 42
+        const count = -10
+
+        await bchjs.Electrumx.blockHeader(height, count)
+        assert.equal(true, false, "Unexpected result!")
+      } catch (err) {
+        // console.log(`err: `, err)
+        assert.include(err.error, `count must be a positive number`)
+      }
+    })
+    it(`should GET block headers for a given height`, async () => {
+      // Stub the network call.
+      sandbox.stub(axios, "get").resolves({ data: mockData.blockHeaders })
+
+      const height = 42
+
+      const result = await bchjs.Electrumx.blockHeader(height)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+      assert.isArray(result)
+      assert.equal(result.length, 2)
+    })
+  })
 })

--- a/test/unit/fixtures/electrumx-mock.js
+++ b/test/unit/fixtures/electrumx-mock.js
@@ -158,6 +158,11 @@ const unconfirmedArray = {
   ]
 }
 
+const blockHeaders = [
+  '010000008b52bbd72c2f49569059f559c1b1794de5192e4f7d6d2b03c7482bad0000000083e4f8a9d502ed0c419075c1abb5d56f878a2e9079e5612bfb76a2dc37d9c42741dd6849ffff001d2b909dd6',
+  '01000000f528fac1bcb685d0cd6c792320af0300a5ce15d687c7149548904e31000000004e8985a786d864f21e9cbb7cbdf4bc9265fe681b7a0893ac55a8e919ce035c2f85de6849ffff001d385ccb7c'
+]
+
 module.exports = {
   utxo,
   utxos,
@@ -166,5 +171,6 @@ module.exports = {
   transaction,
   transactions,
   unconfirmed,
-  unconfirmedArray
+  unconfirmedArray,
+  blockHeaders
 }


### PR DESCRIPTION
**Issue**: #6

* Added `blockHeader` method to the `Electrumx` class in the `electrumx.js` file
* `api-doc` documentation and examples added
* Integration tests for both `mainnet` and `testnet` added
* Unit tests and mocks added