### PR TITLE
fix(generateBurnOpReturn): Added handler when burning amount is higher than token amount

### DIFF
--- a/src/slp/tokentype1.js
+++ b/src/slp/tokentype1.js
@@ -220,7 +220,12 @@ class TokenType1 {
       // Calculate the total amount of tokens owned by the wallet.
       let totalTokens = 0
       for (let i = 0; i < tokenUtxos.length; i++) {
-        totalTokens += tokenUtxos[i].tokenQty
+        totalTokens += parseFloat(tokenUtxos[i].tokenQty)
+      }
+
+      // Make sure burn quantity isn't bigger than the total amount in tokens
+      if (burnQty > totalTokens) {
+        burnQty = totalTokens
       }
 
       const remainder = totalTokens - burnQty

--- a/test/unit/slp-tokentype1.js
+++ b/test/unit/slp-tokentype1.js
@@ -1217,11 +1217,11 @@ describe('#SLP TokenType1', () => {
           tokenDocumentUrl: '',
           tokenDocumentHash: '',
           decimals: 8,
-          tokenQty: 7
+          tokenQty: '7'
         }
       ]
 
-      const result = bchjs.SLP.TokenType1.generateBurnOpReturn(tokenUtxos, 1)
+      const result = bchjs.SLP.TokenType1.generateBurnOpReturn(tokenUtxos, 8)
       // console.log(`result: ${JSON.stringify(result, null, 2)}`)
       // console.log(`result: `, result)
 


### PR DESCRIPTION
Small update to handle an error I encountered while working with the generateBurnOpReturn. There was a strange behavior when trying to burn more tokens than there are available in a given collection of utxos. 

The scope of this pull request is to add a handler to control this behavior. [Here's the trello task](https://trello.com/c/kg2xD9bO)