### PR TITLE
Return parent NFT group token information

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "The FullStack.cash JavaScript library for Bitcoin Cash and SLP Tokens",
   "author": "Chris Troutner <chris.troutner@gmail.com>",
   "contributors": [
-    "Gabriel Cardona <gabriel@bitcoin.com>"
+    "Gabriel Cardona <gabriel@bitcoin.com>",
+    "Stoyan Zhekov <zh@zhware.net>"
   ],
   "main": "src/bch-js",
   "scripts": {
     "test": "nyc mocha --trace-warnings --unhandled-rejections=strict --timeout 30000 test/unit/",
     "test:integration": "npm run test:integration:bchn",
+    "test:integration:nft": "export RESTURL=https://bchn.fullstack.cash/v4/ && export IS_USING_FREE_TIER=true && mocha --timeout 30000 -g '#nft1' test/integration/chains/bchn/slp.js",
     "test:integration:abc": "export RESTURL=https://abc.fullstack.cash/v4/ && export IS_USING_FREE_TIER=true && mocha --timeout 30000 test/integration/ && mocha --timeout 30000 test/integration/chains/abc/",
     "test:integration:bchn": "export RESTURL=https://bchn.fullstack.cash/v4/ && export IS_USING_FREE_TIER=true && mocha --timeout 30000 test/integration/ && mocha --timeout 30000 test/integration/chains/bchn/",
     "test:integration:testnet": "IS_USING_FREE_TIER=true mocha --timeout 30000 test/integration/chains/testnet/",

--- a/src/slp/nft1.js
+++ b/src/slp/nft1.js
@@ -458,6 +458,58 @@ class Nft1 {
       else throw error
     }
   }
+
+  /**
+   * @api SLP.Nft1.parentNFTGroup() parentNFTGroup()
+   * @apiName parentNFTGroup
+   * @apiGroup SLP Nft1
+   * @apiDescription Return parent NFT Group information for a given NFT child token.
+   * It's assumed provided groupId parameter is for an NFT Child token (type=65)
+   *
+   * Returns a JSON with NFT group information.
+   *
+   * @apiExample Example usage:
+   *
+   * const tokenId = '45a30085691d6ea586e3ec2aa9122e9b0e0d6c3c1fd357decccc15d8efde48a9'
+   * const group = await bchjs.SLP.Nft1.parentNFTGroup(tokenId)
+   *
+   * group = {
+   *   "nftGroup": {
+   *     "decimals": 0,
+   *     "timestamp": "2021-05-03 10:36:01",
+   *     "timestamp_unix": 1620038161,
+   *     "versionType": 129,
+   *     "documentUri": "psfoundation.cash",
+   *     "symbol": "PSF.TEST.GROUP",
+   *     "name": "PSF Test NFT Group",
+   *     "containsBaton": true,
+   *     "id": "68cd33ecd909068fbea318ae5ff1d6207cf754e53b191327d6d73b6916424c0a",
+   *     "documentHash": null,
+   *     "initialTokenQty": 1000000,
+   *     "blockCreated": 686117,
+   *     "totalMinted": null,
+   *     "totalBurned": null,
+   *     "circulatingSupply": null
+   *   }
+   * }
+   */
+  async parentNFTGroup (tokenId) {
+    try {
+      if (typeof tokenId === 'string') {
+        const response = await axios.get(
+          `${this.restURL}slp/nftGroup/${tokenId}`,
+          _this.axiosOptions
+        )
+        return response.data
+      }
+
+      throw new Error('tokenId must be a string.')
+    } catch (error) {
+      // console.log('Error in parentNFTGroup()')
+      if (error.response && error.response.data) throw error.response.data
+      else throw error
+    }
+  }
 }
 
 module.exports = Nft1

--- a/test/integration/chains/bchn/slp.js
+++ b/test/integration/chains/bchn/slp.js
@@ -266,12 +266,26 @@ describe('#SLP', () => {
   })
   describe('#nft1', () => {
     describe('#listNFTGroupChildren', () => {
-      it.only('should return array of children GENESIS transactions IDs', async () => {
+      it('should return array of children GENESIS transactions IDs', async () => {
         const groupId = '68cd33ecd909068fbea318ae5ff1d6207cf754e53b191327d6d73b6916424c0a'
         const result = await bchjs.SLP.NFT1.listNFTGroupChildren(groupId)
         // console.log(`result: ${JSON.stringify(result, null, 2)}`)
         assert.property(result, 'nftChildren')
         assert.isArray(result.nftChildren)
+      })
+    })
+    describe('#parentNFTGroup', () => {
+      it('should return parent NFT group information', async () => {
+        const tokenId = '45a30085691d6ea586e3ec2aa9122e9b0e0d6c3c1fd357decccc15d8efde48a9'
+        const result = await bchjs.SLP.NFT1.parentNFTGroup(tokenId)
+        // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+        assert.property(result, 'nftGroup')
+        assert.property(result.nftGroup, 'id')
+        assert.property(result.nftGroup, 'name')
+        assert.property(result.nftGroup, 'symbol')
+        assert.property(result.nftGroup, 'documentUri')
+        assert.property(result.nftGroup, 'versionType')
+        assert.property(result.nftGroup, 'initialTokenQty')
       })
     })
   })

--- a/test/unit/fixtures/slp/mock-utils.js
+++ b/test/unit/fixtures/slp/mock-utils.js
@@ -126,6 +126,26 @@ const mockNftChildrenList = {
   ]
 }
 
+const mockNftGroup = {
+  nftGroup: {
+    decimals: 0,
+    timestamp: '2021-05-03 10:36:01',
+    timestamp_unix: 1620038161,
+    versionType: 129,
+    documentUri: 'psfoundation.cash',
+    symbol: 'PSF.TEST.GROUP',
+    name: 'PSF Test NFT Group',
+    containsBaton: true,
+    id: '68cd33ecd909068fbea318ae5ff1d6207cf754e53b191327d6d73b6916424c0a',
+    documentHash: null,
+    initialTokenQty: 1000000,
+    blockCreated: 686117,
+    totalMinted: null,
+    totalBurned: null,
+    circulatingSupply: null
+  }
+}
+
 const balancesForAddress = [
   {
     tokenId: 'df808a41672a0a0ae6475b44f272a107bc9961b90f29dc918d71301f24fe92fb',
@@ -1396,6 +1416,7 @@ module.exports = {
   mockToken,
   mockTokens,
   mockNftChildrenList,
+  mockNftGroup,
   balancesForAddress,
   balancesForAddresses,
   mockRawTx,

--- a/test/unit/slp-nft1.js
+++ b/test/unit/slp-nft1.js
@@ -296,4 +296,52 @@ describe('#SLP NFT1', () => {
       assert.isArray(result.nftChildren)
     })
   })
+  describe('#parentNFTGroup', () => {
+    it('should throw an error for improper input', async () => {
+      try {
+        const tokenId = 12345
+
+        await bchjs.SLP.NFT1.parentNFTGroup(tokenId)
+        assert.equal(true, false, 'Unexpected result!')
+      } catch (err) {
+        // console.log(`err: `, err)
+        assert.include(
+          err.message,
+          'tokenId must be a string'
+        )
+      }
+    })
+    it('should handle API response error', async () => {
+      try {
+        const error = new Error()
+        error.response = {
+          error: 'NFT child does not exists'
+        }
+        sandbox.stub(axios, 'get').throws(error)
+
+        const tokenId = 'non-exists'
+        await bchjs.SLP.NFT1.parentNFTGroup(tokenId)
+      } catch (err) {
+        assert.include(
+          err.response,
+          { error: 'NFT child does not exists' }
+        )
+      }
+    })
+    it('should return parent NFT group information', async () => {
+      sandbox.stub(axios, 'get').resolves({ data: mockData.mockNftGroup })
+
+      const tokenId = '45a30085691d6ea586e3ec2aa9122e9b0e0d6c3c1fd357decccc15d8efde48a9'
+      const result = await bchjs.SLP.NFT1.parentNFTGroup(tokenId)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.property(result, 'nftGroup')
+      assert.property(result.nftGroup, 'id')
+      assert.property(result.nftGroup, 'name')
+      assert.property(result.nftGroup, 'symbol')
+      assert.property(result.nftGroup, 'documentUri')
+      assert.property(result.nftGroup, 'versionType')
+      assert.property(result.nftGroup, 'initialTokenQty')
+    })
+  })
 })


### PR DESCRIPTION
The scope of this task is to add an endpoint to the `bch-js nft1.js` library that calls the new `bch-api` endpoint for getting parent NFT group token information for a given NFT child token.

The PR for this task should also include unit and integration tests for the new endpoint.