### PR TITLE
changed getBchaUsd which returns the price for the BCHA denomination, added getXecUsd for the XEC denomination

### DIFF
--- a/src/price.js
+++ b/src/price.js
@@ -127,8 +127,9 @@ class Price {
    * @apiName Price getBchaUsd()
    * @apiGroup Price
    * @apiDescription Return current price of BCHA in USD.
-   * This endpoint gets the USD price of BCHA from the Coinex API. The price
-   * comes from bch-api, so it has a better chance of working in Tor.
+   * This endpoint gets the USD price of XEC from the Coinex API. The price
+   * denominated in BCHA comes from bch-api, so it has a better chance of 
+   * working in Tor.
    *
    * @apiExample Example usage:
    *(async () => {
@@ -140,9 +141,47 @@ class Price {
    *  }
    *})()
    *
-   * // 18.81
+   * // 212.34
    */
   async getBchaUsd () {
+    try {
+      const response = await this.axios.get(
+        `${this.restURL}price/bchausd`,
+        this.axiosOptions
+      )
+      // console.log(`response.data: ${JSON.stringify(response.data, null, 2)}`)
+      
+      const bchaPrice = response.data.usd * 1000000
+      // Convert XEC denomination to BCHA denomination
+
+      return bchaPrice
+    } catch (err) {
+      if (err.response && err.response.data) throw err.response.data
+      else throw err
+    }
+  }
+
+    /**
+   * @api price.getXecUsd() getXecUsd()
+   * @apiName Price getXecUsd()
+   * @apiGroup Price
+   * @apiDescription Return current price of XEC in USD.
+   * This endpoint gets the USD price of XEC from the Coinex API. The price
+   * comes from bch-api, so it has a better chance of working in Tor.
+   *
+   * @apiExample Example usage:
+   *(async () => {
+   *  try {
+   *    let current = await bchjs.Price.getXecUsd();
+   *    console.log(current);
+   *  } catch(err) {
+   *   console.err(err)
+   *  }
+   *})()
+   *
+   * // 0.00021234 
+   */
+   async getXecUsd () {
     try {
       const response = await this.axios.get(
         `${this.restURL}price/bchausd`,


### PR DESCRIPTION
Minimal change which alters the getBchaUsd function to be in line with its name and return the price of the BCHA denomination.
This is how the function used to work before the re-denomination of CoinEx, so this is restoring the intended behavior without breaking any applications relying on bch-js.

The new getXecUsd function is to return the price of the new XEC denomination, this is the rebranded denomination and is functionally and code-wise the same as the unintentionally changed getBchaUsd.