### PR TITLE
conversion between bitcoincash: and ecash:

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "bip66": "^1.1.5",
         "bitcoinjs-message": "^2.0.0",
         "bs58": "^4.0.1",
-        "cashaddrjs": "^0.3.3",
+        "ecashaddrjs": "^1.0.7",
         "ini": "^1.3.8",
         "randombytes": "^2.0.6",
         "safe-buffer": "^5.1.2",
@@ -2099,28 +2099,12 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "node_modules/cashaddrjs": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/cashaddrjs/-/cashaddrjs-0.3.12.tgz",
-      "integrity": "sha512-GdjCYMVwd86HXcFcxyEZQLPLFv8a/u0ccYPsO0PpnUW26LhZzHX9l9QA+DjaeUah7tnebwPs33NWDbbUy8iVYQ==",
-      "dependencies": {
-        "big-integer": "1.6.36"
-      }
-    },
     "node_modules/cashaddrjs-slp": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/cashaddrjs-slp/-/cashaddrjs-slp-0.2.12.tgz",
       "integrity": "sha512-n2TTIuW6vZZxYvjvsUAA+wOM0Zkj+3RRKUtDC1XSu4Ic4XVr0yFJkl1bzQkHWda7nkVT51sxjZneygz7D0SyrQ==",
       "dependencies": {
         "big-integer": "^1.6.34"
-      }
-    },
-    "node_modules/cashaddrjs/node_modules/big-integer": {
-      "version": "1.6.36",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
-      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/chai": {
@@ -2871,6 +2855,22 @@
       "dev": true,
       "dependencies": {
         "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/ecashaddrjs": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ecashaddrjs/-/ecashaddrjs-1.0.7.tgz",
+      "integrity": "sha512-KsvHYLlYtLr/GBkEPiwwQDIDBzqRx61qC34n1puHKOjVE4Uwg3syHccjFCqNynLa6T6xI0Rd7ByCRUJcuJcoIw==",
+      "dependencies": {
+        "big-integer": "1.6.36"
+      }
+    },
+    "node_modules/ecashaddrjs/node_modules/big-integer": {
+      "version": "1.6.36",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -17837,21 +17837,6 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "cashaddrjs": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/cashaddrjs/-/cashaddrjs-0.3.12.tgz",
-      "integrity": "sha512-GdjCYMVwd86HXcFcxyEZQLPLFv8a/u0ccYPsO0PpnUW26LhZzHX9l9QA+DjaeUah7tnebwPs33NWDbbUy8iVYQ==",
-      "requires": {
-        "big-integer": "1.6.36"
-      },
-      "dependencies": {
-        "big-integer": {
-          "version": "1.6.36",
-          "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
-          "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
-        }
-      }
-    },
     "cashaddrjs-slp": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/cashaddrjs-slp/-/cashaddrjs-slp-0.2.12.tgz",
@@ -18481,6 +18466,21 @@
       "dev": true,
       "requires": {
         "readable-stream": "^2.0.2"
+      }
+    },
+    "ecashaddrjs": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ecashaddrjs/-/ecashaddrjs-1.0.7.tgz",
+      "integrity": "sha512-KsvHYLlYtLr/GBkEPiwwQDIDBzqRx61qC34n1puHKOjVE4Uwg3syHccjFCqNynLa6T6xI0Rd7ByCRUJcuJcoIw==",
+      "requires": {
+        "big-integer": "1.6.36"
+      },
+      "dependencies": {
+        "big-integer": {
+          "version": "1.6.36",
+          "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+          "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
+        }
       }
     },
     "ecc-jsbn": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bip66": "^1.1.5",
     "bitcoinjs-message": "^2.0.0",
     "bs58": "^4.0.1",
-    "cashaddrjs": "^0.3.3",
+    "ecashaddrjs": "^1.0.7",
     "ini": "^1.3.8",
     "randombytes": "^2.0.6",
     "safe-buffer": "^5.1.2",

--- a/src/address.js
+++ b/src/address.js
@@ -1,6 +1,6 @@
 // const axios = require("axios")
 const Bitcoin = require('@psf/bitcoincashjs-lib')
-const cashaddr = require('cashaddrjs')
+const cashaddr = require('ecashaddrjs')
 const coininfo = require('@psf/coininfo')
 
 class Address {
@@ -121,6 +121,63 @@ class Address {
 
     const cashAddress = cashaddr.encode(
       prefixString,
+      decoded.type,
+      decoded.hash
+    )
+
+    if (prefix) return cashAddress
+    return cashAddress.split(':')[1]
+  }
+
+  /**
+   * @api Address.toEcashAddress() toEcashAddress()
+   * @apiName toEcashAddress
+   * @apiGroup Address
+   * @apiDescription Convert legacy to cashAddress format
+   *
+   * @apiExample Example usage:
+   * // mainnet
+   * bchjs.Address.toEcashAddress('bitcoincash:qq50d800hgunr8u4trz3uuppspk3mds0dy9978plt2')
+   * // ecash:qq50d800hgunr8u4trz3uuppspk3mds0dyug2v69da
+   *
+   * // mainnet no prefix
+   * bchjs.Address.toEcashAddress('bitcoincash:qq50d800hgunr8u4trz3uuppspk3mds0dy9978plt2', false)
+   * // qq50d800hgunr8u4trz3uuppspk3mds0dyug2v69da
+   *
+   */
+   toEcashAddress (address, prefix = true) {
+    const decoded = this._decode(address)
+
+    const ecashAddress = cashaddr.encode(
+      'ecash',
+      decoded.type,
+      decoded.hash
+    )
+
+    if (prefix) return ecashAddress
+    return ecashAddress.split(':')[1]
+  }
+
+  /**
+   * @api Address.ecashtoCashAddress() ecashtoCashAddress()
+   * @apiName ecashtoCashAddress
+   * @apiGroup Address
+   * @apiDescription Convert legacy to cashAddress format
+   *
+   * @apiExample Example usage:
+   * // mainnet
+   * bchjs.Address.ecashtoCashAddress('ecash:qq50d800hgunr8u4trz3uuppspk3mds0dyug2v69da')
+   * // bitcoincash:qq50d800hgunr8u4trz3uuppspk3mds0dy9978plt2
+   *
+   * // mainnet no prefix
+   * bchjs.Address.ecashtoCashAddress('ecash:qq50d800hgunr8u4trz3uuppspk3mds0dyug2v69da', false)
+   * // qq50d800hgunr8u4trz3uuppspk3mds0dy9978plt2
+   */
+   ecashtoCashAddress (address, prefix = true) {
+    const decoded = this._decodeEcashAddress(address)
+
+    const cashAddress = cashaddr.encode(
+      'bitcoincash',
       decoded.type,
       decoded.hash
     )
@@ -266,6 +323,22 @@ class Address {
         cashAddress: this.hash160ToCash(address),
         format: 'hash160'
       }
+    } catch (error) {}
+
+    throw new Error(`Invalid format : ${address}`)
+  }
+
+  _decodeEcashAddress (address) {
+    if (address.indexOf(':') !== -1) {
+      const decoded = cashaddr.decode(address)
+      decoded.format = 'cashaddr'
+      return decoded
+    }
+
+    try {
+      const decoded = cashaddr.decode(`ecash:${address}`)
+      decoded.format = 'cashaddr'
+      return decoded
     } catch (error) {}
 
     throw new Error(`Invalid format : ${address}`)


### PR DESCRIPTION
Upgraded bch-js to support ecash.
Swapped the library cashaddrjs out for the fork ecashaddrjs that supports the ecash: format.
Added two new functions toEcashAddress() and ecashtoCashAddress() for convert back and forth.