### PR TITLE
clarified some of the documentation

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -223,7 +223,7 @@ class Address {
    * @api Address.hash160ToCash() hash160ToCash()
    * @apiName hash160ToCash
    * @apiGroup Address
-   * @apiDescription Convert hash160 to cash address.
+   * @apiDescription Convert hash160 to cash address. Accepts either hexadecimal or buffer.
    *
    * @apiExample Example usage:
    * bchjs.Address.hash160ToCash("573d93b475be4f1925f3b74ed951201b0147eac1")
@@ -794,13 +794,13 @@ class Address {
    * @apiDescription Detect an addess from an OutputScript..
    *
    * @apiExample Example usage:
-   *  const script = bchjs.Script.encode([
+   *  const scriptBuffer = bchjs.Script.encode([
    *    Buffer.from("BOX", "ascii"),
    *    bchjs.Script.opcodes.OP_CAT,
    *    Buffer.from("BITBOX", "ascii"),
    *    bchjs.Script.opcodes.OP_EQUAL
    *  ]);
-   *  const p2sh_hash160 = bchjs.Crypto.hash160(script);
+   *  const p2sh_hash160 = bchjs.Crypto.hash160(scriptBuffer);
    *  const scriptPubKey = bchjs.Script.scriptHash.output.encode(p2sh_hash160);
    *
    *  // mainnet address from output script

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -60,7 +60,7 @@ class Crypto {
    * @api Crypto.hash256() hash256()
    * @apiName hash256
    * @apiGroup Crypto
-   * @apiDescription Utility for creating double sha256 hash digests of data.
+   * @apiDescription Utility for creating double sha256 hash digests of buffer encoded data.
    *
    * @apiExample Example usage:
    *   // buffer from hex
@@ -86,7 +86,7 @@ class Crypto {
    * @api Crypto.hash160() hash160()
    * @apiName hash160
    * @apiGroup Crypto
-   * @apiDescription Utility for creating ripemd160(sha256()) hash digests of data.
+   * @apiDescription Utility for creating ripemd160(sha256()) hash digests of buffer encoded data.
    *
    * @apiExample Example usage:
    *  // buffer from hex


### PR DESCRIPTION
Now says explicitly that data arguments of hash functions should be buffer encoded.
Added that hash160ToCash() also accepts buffer as an argument.
Clarified in fromOutputScript() example that script in is buffer encoded by renaming it to "scriptBuffer".