### PR TITLE
- Changed the stub method to `resolvesArg`

### DIFF
--- a/test/unit/utxo-unit.js
+++ b/test/unit/utxo-unit.js
@@ -254,7 +254,7 @@ describe('#utxo', () => {
         .resolves({ txData: { isValidSlp: false } })
 
       // Mock function to return the same input. Good enough for this test.
-      sandbox.stub(bchjs.Utxo, 'hydrateTokenData').resolves(x => x)
+      sandbox.stub(bchjs.Utxo, 'hydrateTokenData').resolvesArg(0)
 
       const addr = 'simpleledger:qrm0c67wwqh0w7wjxua2gdt2xggnm90xwsr5k22euj'
 


### PR DESCRIPTION
The proper way to use an identity function as a stub for a promise in sinon.js is to use `resolvesArg(0)`. Because of this the `tokens` attribute was set to an anonymous function instead of the expected value.

And the funny thing is the test was passing because it was only checking the length attribute to be one, which would also be true for an anonymous function. 