### PR TITLE
feat(getPsffppPrice): New endpoint to get PSFFPP pin price

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ wallet.json
 integration-test-sweet.sh
 integration-test-ss.sh
 integration-test-bitfinex.sh
+integration-test-pearson.sh
 
 docs/
 coverage/

--- a/src/price.js
+++ b/src/price.js
@@ -230,6 +230,42 @@ class Price {
       else throw err
     }
   }
+
+  /**
+   * @api price.getPsffppPrice() getPsffppPrice()
+   * @apiName Price getPsffppPrice()
+   * @apiGroup Price
+   * @apiDescription Return the cost in PSF tokens to write 1MB of data to the PSFFPP
+   * Find out more at PSFFPP.com. This is a IPFS pinning service that can pin
+   * up to 100MB per transaction into its network. The cost is denominated in
+   * PSF SLP tokens. The endpoint returns the cost to pin 1MB of data to the
+   * PSFFPP network.
+   *
+   * @apiExample Example usage:
+   *(async () => {
+   *  try {
+   *    let current = await bchjs.Price.getPsffppPrice();
+   *    console.log(current);
+   *  } catch(err) {
+   *   console.error(err)
+   *  }
+   *})()
+   *
+   * // 0.08335233
+   */
+  async getPsffppPrice () {
+    try {
+      const response = await this.axios.get(
+         `${this.restURL}price/psffpp`,
+         this.axiosOptions
+      )
+
+      return response.data.writePrice
+    } catch (err) {
+      if (err.response && err.response.data) throw err.response.data
+      else throw err
+    }
+  }
 }
 
 module.exports = Price

--- a/test/integration/price.js
+++ b/test/integration/price.js
@@ -52,6 +52,15 @@ describe('#price', () => {
       assert.property(result, 'CAD')
     })
   })
+
+  describe('#getPsffppPrice', () => {
+    it('should get the price of BCH in several currencies', async () => {
+      const result = await bchjs.Price.getPsffppPrice()
+      // console.log(result)
+
+      assert.isNumber(result)
+    })
+  })
 })
 
 function sleep (ms) {


### PR DESCRIPTION
New endpoint `await bchjs.Price.getPsffppPrice()` retrieves the cost to pin 1MB of content to the PSFFPP network. The cost is denominated in PSF SLP tokens.