### PR TITLE
Add ElectrumX merkle branch method

### DIFF
--- a/src/electrumx.js
+++ b/src/electrumx.js
@@ -580,6 +580,90 @@ class ElectrumX {
   }
 
   /**
+   * @api Electrumx.merkleBranch() merkleBranch()
+   * @apiName ElectrumX merkleBranch
+   * @apiGroup ElectrumX
+   * @apiDescription Returns the merkle branch for a transaction.
+   *
+   * @apiExample Example usage:
+   *    (async () => {
+   *   try {
+   *     let result = await bchjs.Electrumx.merkleBranch('a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d', 617812)
+   *     console.log(result);
+   *   } catch(error) {
+   *    console.error(error)
+   *   }
+   * })()
+   *
+   * result = {
+   *   "success": true,
+   *   "merkle": {
+   *     "block_height": 617812,
+   *     "merkle": [
+   *       "..."
+   *     ],
+   *     "pos": 4
+   *   }
+   * }
+   *
+   *    (async () => {
+   *   try {
+   *     let result = await bchjs.Electrumx.merkleBranch([{ txid: 'a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d', height: 617812 }])
+   *     console.log(result);
+   *   } catch(error) {
+   *    console.error(error)
+   *   }
+   * })()
+   *
+   * result = {
+   *   "success": true,
+   *   "branches": [
+   *     {
+   *       "txid": "a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d",
+   *       "height": 617812,
+   *       "merkle": {
+   *         "block_height": 617812,
+   *         "merkle": [
+   *           "..."
+   *         ],
+   *         "pos": 4
+   *       }
+   *     }
+   *   ]
+   * }
+   */
+  async merkleBranch (txid, height) {
+    try {
+      // Handle single transaction.
+      if (typeof txid === 'string') {
+        const response = await this.axios.get(
+          `${this.restURL}fulcrum/tx/merkle/${txid}/${height}`,
+          this.axiosOptions
+        )
+        return response.data
+      } else if (Array.isArray(txid)) {
+        const response = await this.axios.post(
+          `${this.restURL}fulcrum/tx/merkle`,
+          {
+            txids: txid
+          },
+          this.axiosOptions
+        )
+
+        return response.data
+      }
+
+      throw new Error('Input txId must be a string or array of txid/height objects.')
+    } catch (error) {
+      if (error.response && error.response.data) {
+        const errorData = error.response.data
+        const errorMessage = typeof errorData === 'string' ? errorData : (errorData.error || errorData.message || JSON.stringify(errorData))
+        throw new Error(errorMessage)
+      } else throw error
+    }
+  }
+
+  /**
    * @api Electrumx.broadcast()  broadcast()
    * @apiName ElectrumX Broadcast
    * @apiGroup ElectrumX

--- a/test/integration/electrumx.js
+++ b/test/integration/electrumx.js
@@ -351,6 +351,56 @@ describe('#ElectrumX', () => {
     })
   })
 
+  describe('#merkleBranch', () => {
+    it('should GET merkle branch for a single transaction', async () => {
+      const txid =
+        'a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d'
+      const height = 617812
+
+      const result = await bchjs.Electrumx.merkleBranch(txid, height)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.property(result, 'success')
+      assert.equal(result.success, true)
+
+      assert.property(result, 'merkle')
+      assert.isObject(result.merkle)
+      assert.property(result.merkle, 'block_height')
+      assert.property(result.merkle, 'merkle')
+      assert.property(result.merkle, 'pos')
+      assert.isArray(result.merkle.merkle)
+    })
+
+    it('should POST merkle branch for an array of transactions', async () => {
+      const txids = [
+        {
+          txid: 'a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d',
+          height: 617812
+        },
+        {
+          txid: 'a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d',
+          height: 617812
+        }
+      ]
+
+      const result = await bchjs.Electrumx.merkleBranch(txids)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.property(result, 'success')
+      assert.equal(result.success, true)
+
+      assert.property(result, 'branches')
+      assert.isArray(result.branches)
+
+      assert.property(result.branches[0], 'txid')
+      assert.property(result.branches[0], 'height')
+      assert.property(result.branches[0], 'merkle')
+      assert.property(result.branches[0].merkle, 'block_height')
+      assert.property(result.branches[0].merkle, 'merkle')
+      assert.property(result.branches[0].merkle, 'pos')
+    })
+  })
+
   describe('#broadcast', () => {
     it('should broadcast a single transaction', async () => {
       const txHex =

--- a/test/unit/electrumx.js
+++ b/test/unit/electrumx.js
@@ -391,6 +391,79 @@ describe('#ElectrumX', () => {
     })
   })
 
+  describe('#merkleBranch', () => {
+    it('should throw an error for improper input', async () => {
+      try {
+        const txid = 12345
+
+        await bchjs.Electrumx.merkleBranch(txid)
+        assert.equal(true, false, 'Unexpected result!')
+      } catch (err) {
+        // console.log(`err: `, err)
+        assert.include(
+          err.message,
+          'Input txId must be a string or array of txid/height objects'
+        )
+      }
+    })
+
+    it('should GET merkle branch data for a single transaction', async () => {
+      // Stub the network call.
+      sandbox.stub(axios, 'get').resolves({ data: mockData.merkleBranch })
+
+      const txid =
+        '4db095f34d632a4daf942142c291f1f2abb5ba2e1ccac919d85bdc2f671fb251'
+      const height = 617812
+
+      const result = await bchjs.Electrumx.merkleBranch(txid, height)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.property(result, 'success')
+      assert.equal(result.success, true)
+
+      assert.property(result, 'merkle')
+      assert.isObject(result.merkle)
+      assert.property(result.merkle, 'block_height')
+      assert.property(result.merkle, 'merkle')
+      assert.property(result.merkle, 'pos')
+      assert.isArray(result.merkle.merkle)
+    })
+
+    it('should POST merkle branch data for an array of transactions', async () => {
+      // Stub the network call.
+      sandbox.stub(axios, 'post').resolves({ data: mockData.merkleBranches })
+
+      const txids = [
+        {
+          txid: '4db095f34d632a4daf942142c291f1f2abb5ba2e1ccac919d85bdc2f671fb251',
+          height: 617812
+        },
+        {
+          txid: '4db095f34d632a4daf942142c291f1f2abb5ba2e1ccac919d85bdc2f671fb251',
+          height: 617812
+        }
+      ]
+
+      const result = await bchjs.Electrumx.merkleBranch(txids)
+      // console.log(`result: ${JSON.stringify(result, null, 2)}`)
+
+      assert.property(result, 'success')
+      assert.equal(result.success, true)
+
+      assert.property(result, 'branches')
+      assert.isArray(result.branches)
+
+      assert.property(result.branches[0], 'txid')
+      assert.property(result.branches[0], 'height')
+      assert.property(result.branches[0], 'merkle')
+      assert.property(result.branches[0].merkle, 'block_height')
+      assert.property(result.branches[0].merkle, 'merkle')
+      assert.property(result.branches[0].merkle, 'pos')
+
+      assert.equal(result.branches.length, 2, '2 outputs for 2 inputs')
+    })
+  })
+
   describe('#broadcast', () => {
     it('should throw an error for improper input', async () => {
       try {

--- a/test/unit/fixtures/electrumx-mock.js
+++ b/test/unit/fixtures/electrumx-mock.js
@@ -257,6 +257,34 @@ const detailsArray = {
   ]
 }
 
+const merkleBranch = {
+  success: true,
+  merkle: {
+    block_height: 617812,
+    merkle: [
+      '713d6c7e6ce7bbea708d61162231eaa8ecb31c4c5dd84f81c20409a90069cb24',
+      '03dbaec78d4a52fbaf3c7aa5d3fccd9d8654f323940716ddf5ee2e4bda458fde'
+    ],
+    pos: 4
+  }
+}
+
+const merkleBranches = {
+  success: true,
+  branches: [
+    {
+      txid: txDetails.txid,
+      height: 617812,
+      merkle: merkleBranch.merkle
+    },
+    {
+      txid: txDetails.txid,
+      height: 617812,
+      merkle: merkleBranch.merkle
+    }
+  ]
+}
+
 const broadcast = {
   success: true,
   txid: txDetails.txid
@@ -302,6 +330,8 @@ export default {
   blockHeaders,
   details,
   detailsArray,
+  merkleBranch,
+  merkleBranches,
   broadcast,
   txHistoryWithUnconfirmed
 }


### PR DESCRIPTION
## Issue
Fixes Permissionless-Software-Foundation/bch-js#7.

Depends on Permissionless-Software-Foundation/bch-api#236 for the REST endpoint added by Permissionless-Software-Foundation/bch-api#9.

## Summary
- adds Electrumx.merkleBranch(txid, height) for single transaction GET requests
- supports bulk merkle branch requests via an array of txid/height objects
- adds api-doc examples for single and bulk usage
- adds unit mocks, unit tests, and integration coverage

## Verification
- git diff --check
- node --check src/electrumx.js
- node --check test/unit/electrumx.js
- node --check test/integration/electrumx.js
- node .\node_modules\standard\bin\cmd.cjs --env mocha src\electrumx.js test\unit\electrumx.js test\unit\fixtures\electrumx-mock.js test\integration\electrumx.js
- RESTURL=http://localhost:5942/v6 node .\node_modules\mocha\bin\mocha.js --timeout 30000 --grep "#merkleBranch" test\unit\electrumx.js: 3 passing
- RESTURL=http://localhost:5942/v6 node .\node_modules\mocha\bin\mocha.js --timeout 30000 test\unit\electrumx.js: 30 passing

## Payout
PayPal: https://paypal.me/Jeremytsangchina
Backup USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y